### PR TITLE
fix(ci): resolve latest ai-price-index tag by recency, not lexical

### DIFF
--- a/.github/workflows/pricing-bump.yml
+++ b/.github/workflows/pricing-bump.yml
@@ -81,12 +81,17 @@ jobs:
 
           if [ -z "$tag" ]; then
             # schedule / manual without an explicit tag: resolve the latest
-            # published ai-price-index release tag. Tags are v<YYYY.MM.DD>-<sha>,
-            # which sort lexically in date order, so the highest line wins.
-            tag="$(git ls-remote --tags --refs https://github.com/RoninForge/ai-price-index 'v*' \
-              | awk -F/ '{print $NF}' \
-              | sort \
-              | tail -n 1)"
+            # published ai-price-index release tag. Tags are v<YYYY.MM.DD>-<sha>;
+            # a lexical/version sort is WRONG when several releases land on the
+            # same day, because the trailing <sha> then decides the order
+            # alphabetically rather than by recency (e.g. it would pick
+            # ...becbe72 over the newer ...ace4133). Resolve by the tagged
+            # commit's date instead so the genuinely newest release wins.
+            TMP="$(mktemp -d)"
+            git clone --quiet --bare --filter=blob:none https://github.com/RoninForge/ai-price-index "$TMP/repo"
+            tag="$(git -C "$TMP/repo" for-each-ref --sort=-creatordate \
+              --format='%(refname:short)' 'refs/tags/v*' | head -n 1)"
+            rm -rf "$TMP"
           fi
 
           if [ -z "$tag" ]; then


### PR DESCRIPTION
## Problem

The `pricing-bump.yml` "resolve latest" fallback (scheduled / manual runs with no explicit tag) sorted upstream ai-price-index tags lexically (or with `sort -V`). The tags are `v<YYYY.MM.DD>-<sha>`, so when several releases land on the **same day** the trailing `-<sha>` decides the order alphabetically rather than by recency.

Real example from today, three 2026-06-22 releases:

| tag | release | lexical / `sort -V` picks | recency picks |
|-----|---------|---------------------------|---------------|
| `v2026.06.22-becbe72` | 1.0.1 | ✅ (WRONG) | |
| `v2026.06.22-674c90e` | 1.0.2 | | |
| `v2026.06.22-ace4133` | 1.0.3 (newest) | | ✅ (correct) |

The lexical path silently pinned the **oldest** of the three (1.0.1), stalling the pin bump.

## Fix

Resolve by the tagged commit's date instead, via a shallow bare clone + `for-each-ref --sort=-creatordate`. The tags are lightweight, so `creatordate` is the tagged commit's committer date = true recency.

- Strict tag-format validation regex (the security check) is **unchanged**.
- The `repository_dispatch` / `workflow_dispatch` input-tag paths (which carry the exact tag) are **unchanged** — only the "resolve latest" fallback was touched.

## Validation

Ran the new resolver against the real `RoninForge/ai-price-index` repo: it returns `v2026.06.22-ace4133` (1.0.3), not `...becbe72`. Workflow YAML re-validated with `yaml.safe_load`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)